### PR TITLE
Initial chassis installation, with support for running the next.js server in development and (hopefully) Kubernetes.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.next
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/common-build/chassis:latest
+ENV DJANGO_SETTINGS_MODULE mmlp_editor2.settings
+COPY . /orm/service/
+WORKDIR /orm/service/

--- a/Dockerfile.nextjs
+++ b/Dockerfile.nextjs
@@ -1,0 +1,8 @@
+FROM gcr.io/common-build/orm-node-base:9.11
+ENV NODE_PATH /node_modules/
+COPY package.json /package.json
+RUN npm install
+RUN mkdir -p /orm/service/
+WORKDIR /orm/service/
+COPY . /orm/service/
+RUN /node_modules/.bin/next build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,29 @@
+#!groovy
+
+REGISTRY = 'gcr.io/common-build'
+GCR_CREDENTIALS = 'gcr:gcr-common-build'
+CHASSIS = 'gcr.io/common-build/chassis:latest'
+GITHUB_REPO = 'git@github.com:odewahn/mmlp-editor2.git'
+COMMIT_STATUS_SOURCE = 'ci-jenkins/mmlp_editor2'
+IMAGE_BASE_NAME = 'mmlp_editor2'
+NAMESPACE = 'mmlp-editor2'
+STABLE_BRANCH = 'master'
+PUBLISHED_BRANCHES = ['master']
+DEPLOY_STABLE_TO = ['dev-gke']
+DEPLOY_RELEASES_TO = []
+
+
+
+
+
+
+node('kubectl2') {
+  docker.withRegistry("https://${REGISTRY}", "${GCR_CREDENTIALS}") {
+    stage('Initialize') {
+      sh "docker pull ${CHASSIS}"
+      sh "docker run --rm -e JENKINS=true ${CHASSIS} python /orm/manage.py cat Jenkinsfile.base > Jenkinsfile.base"
+    }
+
+    load 'Jenkinsfile.base'
+  }
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@
 
 # Installation
 
+## With Docker and Compose
+
+```
+docker-compose build
+docker-compose up web
+```
+
+## Local NodeJS installation
+
 Requires Node > 10
 
 ```

--- a/application.json
+++ b/application.json
@@ -1,0 +1,27 @@
+{
+    "chassis_version": "latest",
+    "deploy_version": 2,
+    "description": "A multi-modal learning path editor",
+    "github_repo": "git@github.com:odewahn/mmlp-editor2.git",
+    "kubedir": "kube",
+    "name": "mmlp_editor2",
+    "namespace": "mmlp-editor2",
+    "new_relic_applications": {
+      "dev-seb": "",
+      "prod-sfo": ""
+    },
+    "ports": {
+      "dev": 3000
+    },
+    "slack_channels": [],
+    "slack_names_to_handles": {
+    },
+    "team": "Architecture",
+    "gke_enabled": true,
+    "jenkins": {
+      "stable_branch": "master",
+      "published_branches": ["master"],
+      "deploy_stable_to": ["dev-gke"],
+      "deploy_releases_to": []
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+networks:
+  default:
+    name: mmlp-editor2
+  platform:
+    external: true
+services:
+  manage:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: shell_plus
+    entrypoint: /usr/local/bin/python /orm/manage.py
+    env_file: env.local
+    networks:
+      default: {}
+      platform: {}
+    volumes:
+    - ~/.freeipa:/root/.freeipa
+    - ~/.chassis:/root/.chassis
+    - ./:/orm/service
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.nextjs
+    command: npm run dev
+    env_file: env.local
+    networks:
+      default: {}
+    ports:
+    - 3000:3000
+    volumes:
+    - ./:/orm/service
+version: '2.1'

--- a/env.dev-gke
+++ b/env.dev-gke
@@ -1,0 +1,2 @@
+DEBUG=True
+ENV=qa

--- a/env.local
+++ b/env.local
@@ -1,0 +1,3 @@
+DEBUG=True
+ENV=development
+SECRET_KEY=this is not a secure secret key

--- a/env.prod-sfo
+++ b/env.prod-sfo
@@ -1,0 +1,2 @@
+DEBUG=False
+ENV=production

--- a/env.tests
+++ b/env.tests
@@ -1,0 +1,3 @@
+DEBUG=True
+ENV=tests
+SECRET_KEY=this is not a secure secret key

--- a/mmlp_editor2/features.py
+++ b/mmlp_editor2/features.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.utils.functional import SimpleLazyObject
+
+from chassis.features import DeployableFeature
+from chassis.features.base import PrivatelyIngressed
+
+
+class NextJSDevServer(PrivatelyIngressed, DeployableFeature):
+    docker_compose = SimpleLazyObject(lambda: {
+        'command': 'npm run dev',
+        'ports': [f'{settings.SERVICE_CONF["ports"].get("dev")}:3000']
+    })
+    templates = {
+        'kube/nextjs-deployment.yaml': '/orm/service/mmlp_editor2/kubernetes/nextjs-deployment.yaml',
+        'kube/nextjs-service.yaml': '/orm/service/mmlp_editor2/kubernetes/nextjs-service.yaml',
+    }
+    preflight_steps = {'jenkins'}
+    ingress_service_name = 'http'
+
+    def get_templates(self, context):
+        # Don't deploy an actual VuePress instance to dev-seb
+        if not context.endswith('-gke'):
+            return {}
+        else:
+            return super().get_templates(context)

--- a/mmlp_editor2/kubernetes/nextjs-deployment.yaml
+++ b/mmlp_editor2/kubernetes/nextjs-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: {{SERVICE_CONF.namespace}}
+  name: http
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: {{SERVICE_CONF.namespace}}
+        service: http
+    spec:
+      containers:
+      - name: nginx
+        imagePullPolicy: Always
+        image: gcr.io/common-build/{{SERVICE_CONF.name}}-nextjs:latest
+        command: {{kubernetes.command|as_repr}}
+        resources:
+          requests:
+            cpu: 150m
+            memory: 100Mi
+          limits:
+            cpu: 250m
+            memory: 150Mi
+        ports:
+        - name: http
+          containerPort: 3000
+        env:
+        - name: NEW_RELIC_ENABLED
+          value: "true"
+        - name: NEW_RELIC_NO_CONFIG_FILE
+          value: "true"
+        - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+          value: "true"
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_ENV
+          value: production

--- a/mmlp_editor2/kubernetes/nextjs-service.yaml
+++ b/mmlp_editor2/kubernetes/nextjs-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{SERVICE_CONF.namespace}}
+  name: http
+  labels:
+    app: {{SERVICE_CONF.namespace}}
+    service: http
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000
+  selector:
+    app: {{SERVICE_CONF.namespace}}
+    service: http

--- a/mmlp_editor2/settings.py
+++ b/mmlp_editor2/settings.py
@@ -1,0 +1,39 @@
+from chassis.settings import *
+
+SERVICE_NAME = SERVICE_CONF.name
+
+SERVICE_DOCKERFILES = {
+    '': [
+        'chassis.dockerfile.BASE_IMAGE',
+        'chassis.dockerfile.DJANGO_SETTINGS_ENV',
+        'chassis.dockerfile.COPY_SERVICE',
+    ],
+}
+
+SERVICE_DOCKERFILES = {
+    '': [
+        'chassis.dockerfile.BASE_IMAGE',
+        'chassis.dockerfile.DJANGO_SETTINGS_ENV',
+        'chassis.dockerfile.COPY_SERVICE',
+    ],
+    'nextjs': [
+        [
+            'FROM gcr.io/common-build/orm-node-base:9.11',
+            'ENV NODE_PATH /node_modules/',
+            'COPY package.json /package.json',
+            'RUN npm install',
+            'RUN mkdir -p /orm/service/',
+            'WORKDIR /orm/service/',
+            'COPY . /orm/service/',
+            'RUN /node_modules/.bin/next build'
+        ]
+    ]
+}
+
+SERVICE_FEATURES = {
+    'manage': {'cls': 'chassis.features.Manage'},
+    'web': {
+        'cls': 'mmlp_editor2.features.NextJSDevServer',
+        'dockerfile': 'nextjs',
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Add your project's specific requirements here


### PR DESCRIPTION
This allows the MMLP Editor to run both in local mode (with `npm` commands) and also on the chassis (with `docker-compose`).

The docker image installs npm packages to a global `/node_modules/` directory, as we do with other node projects.  This keeps the docker image self-contained for production builds.

I took a rough stab at the Kubernetes configuration for the service, but we'd have to test some deployments.  At this point, I haven't run `preflight` yet, because I think we'll need to fork this repo into `oreillymedia` in order to "see" it from the build system.